### PR TITLE
Add data store and store window bounds

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,6 +16,10 @@ const signalExtensionId = 'iopnjipkpnmbpjaalcjcpcbfcnjknmmo'
 const signalExtensionPath = process.env.NODE_ENV === 'production'
   ? path.join(__dirname, '..', '..', 'Signal-Desktop')
   : path.join(__dirname, 'Signal-Desktop')
+// use a separate data directory for development
+if (!isProduction) {
+  app.setPath('userData', path.join(app.getPath('appData'), 'signal-muon'))
+}
 
 // Instantiate the userData store
 const store = new Store({

--- a/store.js
+++ b/store.js
@@ -1,0 +1,39 @@
+const electron = require('electron')
+const path = require('path')
+const fs = require('fs')
+
+class Store {
+  constructor (opts) {
+    const isProduction = process.env.NODE_ENV !== 'development'
+    if (!isProduction) {
+      app.setPath('userData', path.join(app.getPath('appData'), 'signal-muon'))
+    }
+    // Use a different userData file for development
+    const configName = isProduction ? opts.configName : opts.configName + '-dev'
+    // Renderer process has to get `app` module via `remote`, whereas the main process can get it directly
+    const userDataPath = (electron.app || electron.remote.app).getPath('userData')
+    this.path = path.join(userDataPath, configName + '.json')
+    this.data = parseDataFile(this.path, opts.defaults)
+    console.log('Using userData located at ' + this.path)
+  }
+
+  get (key) {
+    return this.data[key]
+  }
+
+  set (key, val) {
+    this.data[key] = val
+    fs.writeFile(this.path, JSON.stringify(this.data))
+  }
+}
+
+function parseDataFile (filePath, defaults) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath))
+  } catch (error) {
+    // if there was some kind of error, return the passed in defaults instead.
+    return defaults
+  }
+}
+
+module.exports = Store

--- a/store.js
+++ b/store.js
@@ -5,9 +5,6 @@ const fs = require('fs')
 class Store {
   constructor (opts) {
     const isProduction = process.env.NODE_ENV !== 'development'
-    if (!isProduction) {
-      app.setPath('userData', path.join(app.getPath('appData'), 'signal-muon'))
-    }
     // Use a different userData file for development
     const configName = isProduction ? opts.configName : opts.configName + '-dev'
     // Renderer process has to get `app` module via `remote`, whereas the main process can get it directly


### PR DESCRIPTION
I added a generic store handler, which still stores production and dev settings in different files. It also can handle defaults.

Right now it's only used for storing the window bounds. Bounds are updated when the window is closed.

Are you fine with handling userData this way, @diracdeltas ?
There are no linting errors.

Fixes diracdeltas/signal-muon/issues/24