### PR TITLE
getting ncp with npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "devDependencies": {
     "electron-packager": "brave/electron-packager",
     "electron-prebuilt": "brave/electron-prebuilt",
-    "standard": "^9.0.0",
-    "ncp": "^2.0.0"
+    "standard": "^9.0.0"
   },
   "main": "main.js",
   "standard": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "devDependencies": {
     "electron-packager": "brave/electron-packager",
     "electron-prebuilt": "brave/electron-prebuilt",
-    "standard": "^9.0.0"
+    "standard": "^9.0.0",
+    "ncp": "^2.0.0"
   },
   "main": "main.js",
   "standard": {

--- a/tools/buildPackage.js
+++ b/tools/buildPackage.js
@@ -84,7 +84,7 @@ let extensionsPath = isDarwin
   : path.join(buildDir, 'resources', 'Signal-Desktop')
 
 cmds.push('mkdir -p ' + extensionsPath)
-cmds.push('ncp ./Signal-Desktop ' + extensionsPath)
+cmds.push('node_modules/ncp/bin/ncp ./Signal-Desktop ' + extensionsPath)
 
 if (isLinux) {
   cmds.push('mv Signal-linux-x64/Signal Signal-linux-x64/signal')

--- a/tools/buildPackage.js
+++ b/tools/buildPackage.js
@@ -84,7 +84,7 @@ let extensionsPath = isDarwin
   : path.join(buildDir, 'resources', 'Signal-Desktop')
 
 cmds.push('mkdir -p ' + extensionsPath)
-cmds.push('node_modules/ncp/bin/ncp ./Signal-Desktop ' + extensionsPath)
+cmds.push((isWindows ? 'xcopy /e /i ' : 'cp -R ') + 'Signal-Desktop ' + extensionsPath)
 
 if (isLinux) {
   cmds.push('mv Signal-linux-x64/Signal Signal-linux-x64/signal')


### PR DESCRIPTION
Setting ncp as a project dependency and use it in a build script. It's not a bad idea, isn't it?